### PR TITLE
chore(CP-349): updating internal version to not updated default value

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &tflint.BuiltinRuleSet{
 			Name:    "kramp",
-			Version: "1.0.0",
+			Version: "0.0.0-semantically-released",
 			Rules: []tflint.Rule{
 				rules.NewAuthoritativeIAMPolicyOnFolderLevelRule(),
 				rules.NewAuthoritativeIAMPolicyOnProjectLevelRule(),


### PR DESCRIPTION
Following this advice:
https://semantic-release.gitbook.io/semantic-release/support/faq#why-is-the-package.jsons-version-not-updated-in-my-repository
