### PR TITLE
feat(CP-494): added rules for service accounts and groups

### DIFF
--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -29,7 +29,7 @@ steps:
   - name: "ghcr.io/jqlang/jq:${_JQ_VERSION}"
     id: "validate-output-for-verify-dir"
     dir: "manual_tests/verify"
-    args: [".issues | length == 7", "--exit-status", "tflint_output.json"]
+    args: [".issues | length == 10", "--exit-status", "tflint_output.json"]
   - name: "ghcr.io/jqlang/jq:${_JQ_VERSION}"
     id: "validate-output-for-verify_ignores-dir"
     dir: "manual_tests/verify_ignores"

--- a/main.go
+++ b/main.go
@@ -18,6 +18,9 @@ func main() {
 				rules.NewIAMPolicyOnProjectLevelRule(),
 				rules.NewAuthoritativeIAMPolicyOnResourceLevelRule(),
 				rules.NewCreatingKeyForServiceAccountRule(),
+				rules.NewServiceAccountWithAdminRoleRule(),
+				rules.NewServiceAccountWithBasicRoleRule(),
+				rules.NewGroupWithBasicRoleRule(),
 			},
 		},
 	})

--- a/manual_tests/README.md
+++ b/manual_tests/README.md
@@ -8,49 +8,21 @@ Which is different than what happens in [cloudbuild-test.yaml](../cloudbuild-tes
 
 ---
 
-For example:
+A simple example of how to run the tests locally:
+
+_Prerequisites: `go`, `tflint` and `jq`._
 
 ```shell
-cd ..
-make test && make install
-cd manual_tests/verify
-TFLINT_LOG=debug tflint --enable-plugin=kramp
-cd ..
+(cd .. && make test && make install)
+TFLINT_LOG=debug tflint --enable-plugin=kramp --chdir ./verify
+tflint --enable-plugin=kramp --chdir ./verify --no-color --format=json | jq ".issues"
+tflint --enable-plugin=kramp --chdir ./verify --no-color --format=json | jq ".issues | length"
+tflint --enable-plugin=kramp --chdir ./verify --no-color --format=json | jq ".issues | length == 10"
 ```
 
 ```shell
-cd ..
-make test && make install
-cd manual_tests/verify_ignores
-TFLINT_LOG=debug tflint --enable-plugin=kramp --minimum-failure-severity=notice
-cd ..
-```
-
-Note that for the command below you need to build the plugin for the CPU architecture used by the Docker image.
-See second example to see how to do that.
-
-```shell
-PARENT_DIR=$(dirname "$(pwd)")
-docker run -it --rm \
-  --name "tflint-ruleset-kramp-gcp" \
-  --volume "${PARENT_DIR}/:/workspace/" \
-  --workdir="/workspace/manual_tests/" \
-  --env "USERID=$(id -u):$(id -g)" \
-  --entrypoint="./run_in_cloudbuild.sh" \
-  ghcr.io/terraform-linters/tflint:v0.51.1
-```
-
-This shows how to build a compatible binary for the `tflint` Docker image:
-
-```shell
-cd ..
-docker run -it --rm \
-  --name "tflint-ruleset-kramp" \
-  --volume "$(pwd):/workspace" \
-  --workdir="/workspace" \
-  --env "USERID=$(id -u):$(id -g)" \
-  --entrypoint=sh \
-  golang:1.22-alpine3.19 \
-  -c "go mod tidy && go build && go test -v ./..."
-cd manual_tests
+(cd .. && make test && make install)
+TFLINT_LOG=debug tflint --enable-plugin=kramp --minimum-failure-severity=notice --chdir ./verify_ignores
+tflint --enable-plugin=kramp --chdir ./verify_ignores --no-color --format=json | jq ".issues"
+tflint --enable-plugin=kramp --chdir ./verify_ignores --no-color --format=json | jq ".issues | length == 0"
 ```

--- a/manual_tests/verify/main.tf
+++ b/manual_tests/verify/main.tf
@@ -105,3 +105,30 @@ resource "google_service_account_key" "mykey" {
   service_account_id = google_service_account.myaccount.name
   public_key_type    = "TYPE_X509_PEM_FILE"
 }
+
+# --- service_account_with_admin_role ---
+
+resource "google_pubsub_topic_iam_member" "topic_admin" {
+  project = "your-project-id"
+  topic   = "some-topic"
+  role    = "roles/pubsub.admin"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}
+
+# --- service_account_with_basic_role ---
+
+# Adding suffix '_dummy' to the resource name to avoid from being picked up already by the 'iam_policy_on_project_level' rule
+resource "google_project_iam_member_dummy" "owner" {
+  project = "your-project-id"
+  role    = "roles/owner"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}
+
+# --- group_account_with_basic_role ---
+
+# Adding suffix '_dummy' to the resource name to avoid from being picked up already by the 'iam_policy_on_project_level' rule
+resource "google_project_iam_member_dummy" "owner" {
+  project = "your-project-id"
+  role    = "roles/owner"
+  member  = "group:somegroup@example.com"
+}

--- a/manual_tests/verify_ignores/main.tf
+++ b/manual_tests/verify_ignores/main.tf
@@ -121,3 +121,33 @@ resource "google_service_account_key" "mykey" {
   service_account_id = google_service_account.myaccount.name
   public_key_type    = "TYPE_X509_PEM_FILE"
 }
+
+# --- service_account_with_admin_role ---
+
+# tflint-ignore: service_account_with_admin_role
+resource "google_pubsub_topic_iam_member" "topic_admin" {
+  project = "your-project-id"
+  topic   = "some-topic"
+  role    = "roles/pubsub.admin"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}
+
+# --- service_account_with_basic_role ---
+
+# Adding suffix '_dummy' to the resource name to avoid from being picked up already by the 'iam_policy_on_project_level' rule
+# tflint-ignore: service_account_with_basic_role
+resource "google_project_iam_member_dummy" "owner" {
+  project = "your-project-id"
+  role    = "roles/owner"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}
+
+# --- group_account_with_basic_role ---
+
+# Adding suffix '_dummy' to the resource name to avoid from being picked up already by the 'iam_policy_on_project_level' rule
+# tflint-ignore: group_account_with_basic_role
+resource "google_project_iam_member_dummy" "owner" {
+  project = "your-project-id"
+  role    = "roles/owner"
+  member  = "group:somegroup@example.com"
+}

--- a/rules/authoratitive_iam_policy_on_resource_level_rule.go
+++ b/rules/authoratitive_iam_policy_on_resource_level_rule.go
@@ -23,7 +23,7 @@ func (rule *AuthoritativeIAMPolicyOnResourceLevelRule) Enabled() bool {
 }
 
 func (rule *AuthoritativeIAMPolicyOnResourceLevelRule) Severity() tflint.Severity {
-	return tflint.NOTICE
+	return tflint.WARNING
 }
 
 func (rule *AuthoritativeIAMPolicyOnResourceLevelRule) Link() string {

--- a/rules/commons.go
+++ b/rules/commons.go
@@ -70,6 +70,77 @@ func FindAndReportResourcesForPattern(runner tflint.Runner, rule tflint.Rule, in
 	return nil
 }
 
+// FindAndReportResourcesWithAttributeHavingValue
+// 1. Finds resources that have a name matching the given pattern
+// 2. Then checks for those matching resources if they contain an attribute matching the given name (key in map)
+// 3. And in turn checks for those attributes if they contain a value matching the given pattern (value in map)
+// 4. Reports an issue if all given attribute patterns match
+func FindAndReportResourcesWithAttributeHavingValue(runner tflint.Runner, rule tflint.Rule, resourcesPattern regexp.Regexp, attributeAndValuePatterns map[string]*regexp.Regexp, message string) error {
+
+	// Filter for resources having the attributes that exist in the given map
+	var attributeSchemas []hclext.AttributeSchema
+	for attributeNameKey := range attributeAndValuePatterns {
+		attributeSchemas = append(attributeSchemas, hclext.AttributeSchema{Name: attributeNameKey})
+	}
+
+	body, err := runner.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "resource",
+				LabelNames: []string{"type", "name"},
+				Body: &hclext.BodySchema{
+					Attributes: attributeSchemas,
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range body.Blocks {
+		resourceName := resource.Labels[0]
+
+		if !resourcesPattern.MatchString(resourceName) {
+			logger.Debug(fmt.Sprintf("Resource '%s' doesn't match regex '%s'. Not checking its attributes.", resourceName, resourcesPattern.String()))
+			continue
+		}
+
+		logger.Debug(fmt.Sprintf("Resource '%s' matches regex '%s'. Checking its attributes: %v", resourceName, resourcesPattern.String(), resource.Body.Attributes))
+
+		matchingAttributes := 0
+
+		for attributeName, attribute := range resource.Body.Attributes {
+			attributeValuePattern, exists := attributeAndValuePatterns[attributeName]
+			if !exists {
+				logger.Debug(fmt.Sprintf("Attribute '%s' doesn't have a value pattern. Not checking its value.", attributeName))
+				continue
+			}
+
+			logger.Debug(fmt.Sprintf("Attribute '%s' has a value pattern. Checking its value.", attributeName))
+
+			err := runner.EvaluateExpr(attribute.Expr, func(attributeValue string) error {
+				if attributeValuePattern.MatchString(attributeValue) {
+					logger.Debug(fmt.Sprintf("Resource '%s' has attribute '%s' with value '%s' that matches regex '%s'", resourceName, attributeName, attributeValue, attributeValuePattern.String()))
+					matchingAttributes++
+				}
+				return nil
+			}, nil)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		if matchingAttributes == len(attributeAndValuePatterns) {
+			if err := runner.EmitIssue(rule, fmt.Sprintf("Issue with `%s` resource. %s", resourceName, message), resource.DefRange); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func createMessage(resourceName string, message string) string {
 	msg := fmt.Sprintf("`%s` resource found. %s", resourceName, message)
 	return msg

--- a/rules/group_with_basic_role_rule.go
+++ b/rules/group_with_basic_role_rule.go
@@ -23,7 +23,7 @@ func (rule *GroupWithBasicRoleRule) Enabled() bool {
 }
 
 func (rule *GroupWithBasicRoleRule) Severity() tflint.Severity {
-	return tflint.WARNING
+	return tflint.ERROR
 }
 
 func (rule *GroupWithBasicRoleRule) Link() string {

--- a/rules/group_with_basic_role_rule.go
+++ b/rules/group_with_basic_role_rule.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type GroupWithBasicRoleRule struct {
+	tflint.DefaultRule
+}
+
+func NewGroupWithBasicRoleRule() *GroupWithBasicRoleRule {
+	return &GroupWithBasicRoleRule{}
+}
+
+func (rule *GroupWithBasicRoleRule) Name() string {
+	return "group_account_with_basic_role"
+}
+
+func (rule *GroupWithBasicRoleRule) Enabled() bool {
+	return true
+}
+
+func (rule *GroupWithBasicRoleRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+func (rule *GroupWithBasicRoleRule) Link() string {
+	return GetLinkForRule(rule.Name())
+}
+
+func (rule *GroupWithBasicRoleRule) Check(runner tflint.Runner) error {
+	patternResourceName, err := regexp.Compile("google_.*_iam_*")
+	attributesAndValuePatterns := map[string]*regexp.Regexp{
+		"role":   regexp.MustCompile("roles/(viewer|editor|owner|admin)"),
+		"member": regexp.MustCompile("group:.*"),
+	}
+	message := "Basic role for group found. Normally groups don't require a basic role. Since they grant too many permissions. Please use a specific role that matches what the group needs to do as close as possible."
+	if err != nil {
+		return err
+	}
+	if err := FindAndReportResourcesWithAttributeHavingValue(runner, rule, *patternResourceName, attributesAndValuePatterns, message); err != nil {
+		return err
+	}
+	return nil
+}

--- a/rules/group_with_basic_role_rule_test.go
+++ b/rules/group_with_basic_role_rule_test.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GroupWithBasicRoleRule(t *testing.T) {
+
+	const hclForTest = `
+resource "google_project_iam_member" "owner" {
+  project = "your-project-id"
+  role    = "roles/owner"
+  member  = "group:somegroup@example.com"
+}`
+
+	tests := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name:    "issue found",
+			Content: hclForTest,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGroupWithBasicRoleRule(),
+					Message: "Issue with `google_project_iam_member` resource. Basic role for group found. Normally groups don't require a basic role. Since they grant too many permissions. Please use a specific role that matches what the group needs to do as close as possible.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 45},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewGroupWithBasicRoleRule()
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": test.Content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+			helper.AssertIssues(t, test.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/service_account_with_admin_role_rule.go
+++ b/rules/service_account_with_admin_role_rule.go
@@ -23,7 +23,7 @@ func (rule *ServiceAccountWithAdminRoleRule) Enabled() bool {
 }
 
 func (rule *ServiceAccountWithAdminRoleRule) Severity() tflint.Severity {
-	return tflint.WARNING
+	return tflint.ERROR
 }
 
 func (rule *ServiceAccountWithAdminRoleRule) Link() string {

--- a/rules/service_account_with_admin_role_rule.go
+++ b/rules/service_account_with_admin_role_rule.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type ServiceAccountWithAdminRoleRule struct {
+	tflint.DefaultRule
+}
+
+func NewServiceAccountWithAdminRoleRule() *ServiceAccountWithAdminRoleRule {
+	return &ServiceAccountWithAdminRoleRule{}
+}
+
+func (rule *ServiceAccountWithAdminRoleRule) Name() string {
+	return "service_account_with_admin_role"
+}
+
+func (rule *ServiceAccountWithAdminRoleRule) Enabled() bool {
+	return true
+}
+
+func (rule *ServiceAccountWithAdminRoleRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+func (rule *ServiceAccountWithAdminRoleRule) Link() string {
+	return GetLinkForRule(rule.Name())
+}
+
+func (rule *ServiceAccountWithAdminRoleRule) Check(runner tflint.Runner) error {
+	patternResourceName, err := regexp.Compile("google_.*_iam_*")
+	attributesAndValuePatterns := map[string]*regexp.Regexp{
+		"role":   regexp.MustCompile("roles/.*\\.admin"),
+		"member": regexp.MustCompile("serviceAccount:.*"),
+	}
+	message := "Admin role for service account found. Normally service accounts don't require an admin role. Since administration of resources is done via Terraform and not by the application itself. Please use a more specific role that matches the intended activity of the application (identified by this service account) as close as possible (e.g. `roles/pubsub.publisher` instead of `roles/pubsub.admin` for a topic)."
+	if err != nil {
+		return err
+	}
+	if err := FindAndReportResourcesWithAttributeHavingValue(runner, rule, *patternResourceName, attributesAndValuePatterns, message); err != nil {
+		return err
+	}
+	return nil
+}

--- a/rules/service_account_with_admin_role_rule_test.go
+++ b/rules/service_account_with_admin_role_rule_test.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_ServiceAccountWithAdminRoleRule(t *testing.T) {
+
+	const hclForTest = `
+resource "google_pubsub_topic_iam_member" "topic_admin" {
+  project = "your-project-id"
+  topic   = "some-topic"
+  role    = "roles/pubsub.admin"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}
+
+# Should not trigger an issue
+resource "google_pubsub_topic_iam_member" "topic_publisher" {
+  project = "your-project-id"
+  topic   = "some-topic"
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}`
+
+	tests := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name:    "issue found",
+			Content: hclForTest,
+			Expected: helper.Issues{
+				{
+					Rule:    NewServiceAccountWithAdminRoleRule(),
+					Message: "Issue with `google_pubsub_topic_iam_member` resource. Admin role for service account found. Normally service accounts don't require an admin role. Since administration of resources is done via Terraform and not by the application itself. Please use a more specific role that matches the intended activity of the application (identified by this service account) as close as possible (e.g. `roles/pubsub.publisher` instead of `roles/pubsub.admin` for a topic).",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 56},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewServiceAccountWithAdminRoleRule()
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": test.Content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+			helper.AssertIssues(t, test.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/service_account_with_basic_role_rule.go
+++ b/rules/service_account_with_basic_role_rule.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type ServiceAccountWithBasicRoleRule struct {
+	tflint.DefaultRule
+}
+
+func NewServiceAccountWithBasicRoleRule() *ServiceAccountWithBasicRoleRule {
+	return &ServiceAccountWithBasicRoleRule{}
+}
+
+func (rule *ServiceAccountWithBasicRoleRule) Name() string {
+	return "service_account_with_basic_role"
+}
+
+func (rule *ServiceAccountWithBasicRoleRule) Enabled() bool {
+	return true
+}
+
+func (rule *ServiceAccountWithBasicRoleRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+func (rule *ServiceAccountWithBasicRoleRule) Link() string {
+	return GetLinkForRule(rule.Name())
+}
+
+func (rule *ServiceAccountWithBasicRoleRule) Check(runner tflint.Runner) error {
+	patternResourceName, err := regexp.Compile("google_.*_iam_*")
+	attributesAndValuePatterns := map[string]*regexp.Regexp{
+		"role":   regexp.MustCompile("roles/(viewer|editor|owner|admin)"),
+		"member": regexp.MustCompile("serviceAccount:.*"),
+	}
+	message := "Basic role for service account found. Normally service accounts don't require a basic role. Since they grant too many permissions. Please use a specific role that matches the intended activity of the application (identified by this service account) as close as possible."
+	if err != nil {
+		return err
+	}
+	if err := FindAndReportResourcesWithAttributeHavingValue(runner, rule, *patternResourceName, attributesAndValuePatterns, message); err != nil {
+		return err
+	}
+	return nil
+}

--- a/rules/service_account_with_basic_role_rule.go
+++ b/rules/service_account_with_basic_role_rule.go
@@ -23,7 +23,7 @@ func (rule *ServiceAccountWithBasicRoleRule) Enabled() bool {
 }
 
 func (rule *ServiceAccountWithBasicRoleRule) Severity() tflint.Severity {
-	return tflint.WARNING
+	return tflint.ERROR
 }
 
 func (rule *ServiceAccountWithBasicRoleRule) Link() string {

--- a/rules/service_account_with_basic_role_rule_test.go
+++ b/rules/service_account_with_basic_role_rule_test.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_ServiceAccountWithBasicRoleRule(t *testing.T) {
+
+	const hclForTest = `
+resource "google_project_iam_member" "owner" {
+  project = "your-project-id"
+  role    = "roles/owner"
+  member  = "serviceAccount:your-service@your-project-id.iam.gserviceaccount.com"
+}`
+
+	tests := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name:    "issue found",
+			Content: hclForTest,
+			Expected: helper.Issues{
+				{
+					Rule:    NewServiceAccountWithBasicRoleRule(),
+					Message: "Issue with `google_project_iam_member` resource. Basic role for service account found. Normally service accounts don't require a basic role. Since they grant too many permissions. Please use a specific role that matches the intended activity of the application (identified by this service account) as close as possible.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 45},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewServiceAccountWithBasicRoleRule()
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": test.Content})
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+			helper.AssertIssues(t, test.Expected, runner.Issues)
+		})
+	}
+}


### PR DESCRIPTION
To prevent elevated permissions being granted (e.g. using `pubsub.admin` while `pubsub.publisher` would suffice).

Please understand that this is a public repository. Also visible outside of our organization.

Therefore, make sure that you do not include any sensitive information in your pull request (both code and comments).
