### PR TITLE
chore(CP-573): allow `roles/cloudprofiler.agent` on project level

### DIFF
--- a/rules/iam_policy_on_project_level_rule.go
+++ b/rules/iam_policy_on_project_level_rule.go
@@ -44,6 +44,7 @@ func (rule *IAMPolicyOnProjectLevelRule) Check(runner tflint.Runner) error {
 		"roles/cloudsql.client",                                        // https://cloud.google.com/iam/docs/understanding-roles#cloudsql.client
 		"roles/bigquery.jobUser",                                       // https://cloud.google.com/iam/docs/understanding-roles#bigquery.jobUser
 		"roles/datastore.user",                                         // https://cloud.google.com/iam/docs/understanding-roles#datastore.user
+		"roles/cloudprofiler.agent",                                    // https://cloud.google.com/iam/docs/understanding-roles#cloudprofiler.agent
 		"organizations/344471582607/roles/observability.metricsWriter", // https://github.com/kramphub/kramphub-gcp-iam-tf/pull/338
 	}
 


### PR DESCRIPTION
Please understand that this is a public repository. Also visible outside of our organization.

Therefore, make sure that you do not include any sensitive information in your pull request (both code and comments).
