### PR TITLE
feat(CP-573): allow `roles/pubsub.viewer` on project level

### DIFF
--- a/rules/iam_policy_on_project_level_rule.go
+++ b/rules/iam_policy_on_project_level_rule.go
@@ -45,6 +45,7 @@ func (rule *IAMPolicyOnProjectLevelRule) Check(runner tflint.Runner) error {
 		"roles/bigquery.jobUser",                                       // https://cloud.google.com/iam/docs/understanding-roles#bigquery.jobUser
 		"roles/datastore.user",                                         // https://cloud.google.com/iam/docs/understanding-roles#datastore.user
 		"roles/cloudprofiler.agent",                                    // https://cloud.google.com/iam/docs/understanding-roles#cloudprofiler.agent
+		"roles/pubsub.viewer",                                          // https://cloud.google.com/iam/docs/understanding-roles#pubsub.viewer
 		"organizations/344471582607/roles/observability.metricsWriter", // https://github.com/kramphub/kramphub-gcp-iam-tf/pull/338
 	}
 


### PR DESCRIPTION
Some applications check if a certain subscription or topic exists